### PR TITLE
lvthillo-python-flask-docker to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,12 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.58
+- alias: expose
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.58
+- alias: cleanup
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: cleanup
+  version: 2.3.58
+- name: lvthillo-python-flask-docker
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1


### PR DESCRIPTION
Promote lvthillo-python-flask-docker to version 0.0.1